### PR TITLE
enable multi-page-document-annotation with OCR

### DIFF
--- a/label_studio_ml/examples/tesseract/Dockerfile
+++ b/label_studio_ml/examples/tesseract/Dockerfile
@@ -2,7 +2,6 @@
 ARG PYTHON_VERSION=3.12
 
 FROM python:${PYTHON_VERSION}-slim AS python-base
-ARG TEST_ENV
 
 WORKDIR /app
 
@@ -21,26 +20,12 @@ RUN --mount=type=cache,target="/var/cache/apt",sharing=locked \
         tesseract-ocr tesseract-ocr-chi-sim tesseract-ocr-chi-tra tesseract-ocr-deu git; \
     apt-get autoremove -y
 
-# Install base requirements
-COPY requirements-base.txt .
-RUN --mount=type=cache,target=${PIP_CACHE_DIR},sharing=locked \
-    pip install -r requirements-base.txt
-
-# Install custom requirements
 COPY requirements.txt .
 RUN --mount=type=cache,target=${PIP_CACHE_DIR},sharing=locked \
     pip install -r requirements.txt
-
-# Install test requirements if needed
-COPY requirements-test.txt .
-# build only when TEST_ENV="true"
-RUN --mount=type=cache,target=${PIP_CACHE_DIR},sharing=locked \
-    if [ "$TEST_ENV" = "true" ]; then \
-      pip install -r requirements-test.txt; \
-    fi
 
 COPY . .
 
 EXPOSE 9090
 
-CMD gunicorn --preload --bind :$PORT --workers 1 --threads 8 --timeout 0 _wsgi:app
+CMD gunicorn --reload --bind :$PORT --workers 1 --threads 8 --timeout 0 _wsgi:app

--- a/label_studio_ml/examples/tesseract/docker-compose.yml
+++ b/label_studio_ml/examples/tesseract/docker-compose.yml
@@ -4,14 +4,14 @@ services:
 
   tesseract:
     container_name: tesseract
-    build:
-      context: .
-      args:
-        TEST_ENV: ${TEST_ENV}
+    build: .
+    env_file:
+      - example.env
     ports:
       - 9090:9090
     volumes:
       - "./data/server:/data"
+      - "./:/app"
     environment:
       - LOG_LEVEL=DEBUG
 
@@ -20,21 +20,14 @@ services:
       # Do not use 'localhost' as it does not work within Docker containers.
       # Use prefix 'http://' or 'https://' for the URL always.
       # Determine the actual IP using 'ifconfig' (Linux/Mac) or 'ipconfig' (Windows).
-      - LABEL_STUDIO_HOST=
-      # specify the access token for the label studio if you use file upload
-      - LABEL_STUDIO_ACCESS_TOKEN=
-      # set these variables to use Minio as a storage backend
-      - AWS_ACCESS_KEY_ID=your-MINIO_ROOT_USER
-      - AWS_SECRET_ACCESS_KEY=your-MINIO_ROOT_PASSWORD
-      - AWS_ENDPOINT=http://host.docker.internal:9000
+      - LABEL_STUDIO_URL=
+      - LABEL_STUDIO_API_KEY=
 
   minio:
     container_name: minio
     image: bitnami/minio:latest
-    environment:
-      - MINIO_ROOT_USER=<admin username>
-      - MINIO_ROOT_PASSWORD=<admin password>
-      - MINIO_API_CORS_ALLOW_ORIGIN=*
+    env_file:
+      - example.env
     ports:
       - 9000:9000
       - 9001:9001

--- a/label_studio_ml/examples/tesseract/tesseract.py
+++ b/label_studio_ml/examples/tesseract/tesseract.py
@@ -57,17 +57,19 @@ class BBOXOCR(LabelStudioMLBase):
             'TextArea',
             'Image'
         )
-        task = tasks[0]
-        img_path_url = task["data"][value]
-
         context = kwargs.get('context')
         if context:
             if not context["result"]:
                 return []
 
+            idx = context.get('result')[-1]['to_name'].split("_")[-1]
+            from_name = from_name.replace('{{idx}}', idx)
+            task = tasks[0]
+            img_path_url = task['data']['document'][int(idx)]['url']  # task["data"][value]
             image = self.load_image(img_path_url, task.get('id'))
 
             result = context.get('result')[-1]
+
             meta = self._extract_meta({**task, **result})
             x = meta["x"] * meta["original_width"] / 100
             y = meta["y"] * meta["original_height"] / 100
@@ -78,6 +80,7 @@ class BBOXOCR(LabelStudioMLBase):
                 image.crop((x, y, x + w, y + h)),
                 config=OCR_config
             ).strip()
+
             meta["text"] = result_text
             temp = {
                 "original_width": meta["original_width"],


### PR DESCRIPTION
In `label_studio_ml/examples/tesseract/Dockerfile` please revert `CMD gunicorn --reload` to `CMD gunicorn --preload ` once happy with the setup on EC2 instance. `--reload` is only here to help for development. 